### PR TITLE
feat(options): update options to allow for any logger

### DIFF
--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,3 +1,5 @@
+import { LoggerService } from '@nestjs/common';
+
 export interface MulterExtendedS3Options {
   readonly accessKeyId: string;
   readonly secretAccessKey: string;
@@ -6,4 +8,5 @@ export interface MulterExtendedS3Options {
   readonly basePath: string;
   readonly acl?: string;
   readonly fileSize?: number | string;
+  readonly logger?: LoggerService;
 }

--- a/lib/multer-config.service.ts
+++ b/lib/multer-config.service.ts
@@ -1,6 +1,6 @@
 import AWS from 'aws-sdk';
 import s3Storage from 'multer-sharp-s3';
-import { Injectable, Inject, Logger, BadRequestException } from '@nestjs/common';
+import { Injectable, Inject, Logger, BadRequestException, LoggerService } from '@nestjs/common';
 import { MulterOptionsFactory, MulterModuleOptions } from '@nestjs/platform-express';
 import { MULTER_EXTENDED_S3_OPTIONS } from './constants';
 import { MulterExtendedS3Options } from './interfaces';
@@ -18,7 +18,7 @@ export class MulterConfigService implements MulterS3ConfigService {
   static DEFAULT_REGION: string = 'us-west-2';
   static DEFAULT_MAX_FILESIZE: number = 3145728;
   private readonly S3: AWS.S3;
-  private readonly logger: Logger;
+  private readonly logger: LoggerService;
 
   constructor(@Inject(MULTER_EXTENDED_S3_OPTIONS) private s3Options: MulterExtendedS3Options) {
     AWS.config.update({
@@ -28,7 +28,7 @@ export class MulterConfigService implements MulterS3ConfigService {
     });
 
     this.S3 = new AWS.S3();
-    this.logger = new Logger('NestMulterS3Service Options');
+    this.logger = s3Options.logger || new Logger('NestMulterS3Service Options');
     this.logger.log(JSON.stringify(s3Options));
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,14 +3225,6 @@
         "wide-align": "^1.1.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3737,9 +3729,12 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -9138,6 +9133,11 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",

--- a/tests/src/config/aws.ts
+++ b/tests/src/config/aws.ts
@@ -1,8 +1,9 @@
-import { NestMulterS3Options } from '../../../lib/interfaces';
+import { MulterExtendedS3Options } from '../../../lib/interfaces';
 import {
   IMAGE_UPLOAD_MODULE_BASE_PATH,
   USER_PROFILE_IMAGE_UPLOAD_MODULE_BASE_PATH,
 } from '../../fixtures/base-path.constants';
+import { Logger } from '@nestjs/common';
 
 export default {
   optionA: {
@@ -12,7 +13,7 @@ export default {
     bucket: process.env.AWS_S3_BUCKET_NAME,
     basePath: USER_PROFILE_IMAGE_UPLOAD_MODULE_BASE_PATH,
     fileSize: process.env.AWS_S3_MAX_IMAGE_SIZE,
-  } as NestMulterS3Options,
+  } as MulterExtendedS3Options,
   optionB: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
@@ -21,5 +22,6 @@ export default {
     basePath: IMAGE_UPLOAD_MODULE_BASE_PATH,
     fileSize: 1 * 1024 * 1024,
     acl: 'private',
-  } as NestMulterS3Options,
+    logger: new Logger('Test Logger'),
+  } as MulterExtendedS3Options,
 };


### PR DESCRIPTION
Gonna make this a draft until we feel it is ready.

I'm gonna need you to run the test sweet or provide a docker file that will allow it to run successfully, something about `sharp` is not agreeing with my system. Other than that it is a simple update to the options to allow for a logger to be passed and if not, create a new Nest Logger as you already were. Shouldn't be any problems with it as it is just an option.