### PR TITLE
chore(tools): update lint rules to be more strict

### DIFF
--- a/lib/interfaces/multer-extended-options.interface.ts
+++ b/lib/interfaces/multer-extended-options.interface.ts
@@ -1,9 +1,9 @@
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 
-export type ResizeOptions = {
+export interface ResizeOptions {
   width: number;
   height: number;
-};
+}
 
 export interface PreciseSizeOptions extends ResizeOptions {
   suffix: string;

--- a/lib/multer-config.service.ts
+++ b/lib/multer-config.service.ts
@@ -14,9 +14,9 @@ interface MulterS3ConfigService extends MulterOptionsFactory {
 
 @Injectable()
 export class MulterConfigService implements MulterS3ConfigService {
-  static DEFAULT_ACL: string = 'public-read';
-  static DEFAULT_REGION: string = 'us-west-2';
-  static DEFAULT_MAX_FILESIZE: number = 3145728;
+  static DEFAULT_ACL = 'public-read';
+  static DEFAULT_REGION = 'us-west-2';
+  static DEFAULT_MAX_FILESIZE = 3145728;
   private readonly S3: AWS.S3;
   private readonly logger: LoggerService;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8807,6 +8807,12 @@
         "tsutils": "^2.29.0"
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "tsc-watch": "4.1.0",
     "tsconfig-paths": "3.9.0",
     "tslint": "6.0.0",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "3.7.5"
   },
   "husky": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,18 +1,87 @@
 {
-  "defaultSeverity": "error",
-  "extends": ["tslint:recommended"],
-  "jsRules": {
-    "no-unused-expression": true
-  },
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
   "rules": {
-    "quotemark": [true, "single"],
-    "member-access": [false],
-    "ordered-imports": [false],
-    "max-line-length": [true, 150],
-    "member-ordering": [false],
-    "interface-name": [false],
-    "arrow-parens": false,
-    "object-literal-sort-keys": false
-  },
-  "rulesDirectory": []
+    "arrow-return-shorthand": true,
+    "callable-types": true,
+    "class-name": true,
+    "comment-format": [true, "check-space"],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "import-spacing": true,
+    "indent": [true, "spaces"],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [true, 140],
+    "max-union-size": false,
+    "member-access": false,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": true,
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-super": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-inferrable-types": [true, "ignore-params"],
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unnecessary-initializer": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "prefer-const": true,
+    "quotemark": [true, "single", "warn"],
+    "radix": false,
+    "semicolon": [true, "always"],
+    "trailing-comma": true,
+    "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "unified-signatures": true,
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "no-implicit-dependencies": false,
+    "no-submodule-imports": false,
+    "interface-name": false
+  }
 }


### PR DESCRIPTION
This tslint config pulls some rules I've found useful from Angular, but doesn't depend on the libraries angular uses (like codelyzer). 