### PR TITLE
feat(s3options and configloader): support digitalocean spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ interface MulterExtendedS3Options {
    * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
    */
   readonly acl?: string;
+  /*
+   * AWS Endpoint
+   */
+  readonly endpoint?: string;
   /**
    * Optional parameter for the file size
    * default: 3MB

--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,6 +1,10 @@
 import { LoggerService } from '@nestjs/common';
 
 export interface MulterExtendedS3Options {
+  /*
+   * AWS Endpoint
+   */
+  readonly endpoint?: string;
   /**
    * AWS Access Key ID
    */

--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,10 +1,6 @@
 import { LoggerService } from '@nestjs/common';
 
 export interface MulterExtendedS3Options {
-  /*
-   * AWS Endpoint
-   */
-  readonly endpoint?: string;
   /**
    * AWS Access Key ID
    */
@@ -32,6 +28,10 @@ export interface MulterExtendedS3Options {
    * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
    */
   readonly acl?: string;
+  /*
+   * AWS Endpoint
+   */
+  readonly endpoint?: string;
   /**
    * Optional parameter for the file size
    * default: 3MB

--- a/lib/multer-config.loader.ts
+++ b/lib/multer-config.loader.ts
@@ -24,7 +24,9 @@ export class MulterConfigLoader implements MulterS3ConfigService {
       region: s3Options.region || MulterConfigLoader.DEFAULT_REGION,
     });
 
-    this.S3 = new AWS.S3();
+    this.S3 = new AWS.S3({
+      endpoint: s3Options.endpoint,
+    });
     this.logger = s3Options.logger || new Logger(MulterConfigLoader.name);
     this.logger.log(JSON.stringify(s3Options));
   }


### PR DESCRIPTION
Since digital ocean spaces uses aws sdk and api itself, exposing just the endpoint property so we
can use as the remote