### PR TITLE
Allow request params without setting dynamic path

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ uploadFile(@UploadedFile() file) {
 }
 ```
 
-> **Note**: The route name must be matched with the order of `dynamicPath` property value and its name.
-
 &nbsp;
 
 You may want to store the file with an arbitrary name instead of the original file name. You can do this by passing the `randomFilename` property attribute set to `true` as follows:

--- a/lib/multer-sharp/multer-sharp.ts
+++ b/lib/multer-sharp/multer-sharp.ts
@@ -85,14 +85,17 @@ export class MulterSharp implements StorageEngine, S3Storage {
 
         const routeParams = Object.keys(req.params);
 
-        if (routeParams.length > 0) {
-          if (routeParams.length === storageOpts.dynamicPath.length) {
-            if (routeParams.every((param, i) => param === storageOpts.dynamicPath[i])) {
-              const paramDir = Object.values(req.params).join('/');
-              params.Key = `${Key}/${paramDir}/${originalname}`;
-            }
+        if (routeParams.length > 0 && storageOpts.dynamicPath) {
+          if (typeof storageOpts.dynamicPath === 'string') {
+            params.Key = routeParams.includes(storageOpts.dynamicPath)
+              ? `${Key}/${req.params[storageOpts.dynamicPath]}/${originalname}`
+              : `${Key}/${storageOpts.dynamicPath}/${originalname}`;
           } else {
-            params.Key = `${Key}/${req.params[storageOpts.dynamicPath as string]}/${originalname}`;
+            const paramDir = [];
+            storageOpts.dynamicPath.forEach((pathSegment) => {
+              paramDir.push(routeParams.includes(pathSegment) ? req.params[pathSegment] : pathSegment);
+            });
+            params.Key = `${Key}/${paramDir.join('/')}/${originalname}`;
           }
         } else {
           params.Key = storageOpts.dynamicPath


### PR DESCRIPTION
The current handling of the request parameters does not work out when not setting the `dynamicPath` property. Currently, you either need to set it to a static string value or use at least one of the request parameters within the `dynamicPath` property, otherwise you will encounter an uncaught TypeError here: https://github.com/jeffminsungkim/nestjs-multer-extended/blob/23a5bf0d8249ba852fe1da9d85416d58122dbd15/lib/multer-sharp/multer-sharp.ts#L89  

In addition, since `dynamicPath` is of type `string | string[]` the condition might also be true when setting `dynamicPath` to a string like `ab` and having a route with two request parameters like `:foo/:bar` which will in my opinion also lead to an unexpected behavior because then: `dynamicPath.length === routeParams.length (=== 2)`.

Also, I don't see any reason for enforcing the request parameter order to match the order within the `dynamicPath` property. I would suggest a more flexible solution where the developer can decide in which order the request parameters will be used within the resulting path :). 