### PR TITLE
chore(dependencies): add mime-types@2.1.27 to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10598,18 +10598,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.610.0",
+    "mime-types": "^2.1.27",
     "sharp": "^0.26.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/express": "4.17.8",
     "@types/jest": "26.0.13",
     "@types/jest-when": "2.7.1",
+    "@types/mime-types": "2.1.0",
     "@types/multer": "1.4.4",
     "@types/node": "13.13.5",
     "@types/sharp": "0.26.0",


### PR DESCRIPTION
the `mime-types` module is referenced in the `lib/multer-sharp/multer-sharp.ts` file but not declared
in the `package.json` dependencies. this change adds `mime-types@2.1.27` to the dependency list.