### PR TITLE
feat(config): allow to pass all config options for AWS and S3 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ import { MulterExtendedModule } from 'nestjs-multer-extended';
 @Module({
   imports: [
     MulterExtendedModule.register({
-      accessKeyId: 'YOUR_AWS_ACCESS_KEY_ID',
-      secretAccessKey: 'YOUR_AWS_SECRET_ACCESS_KEY',
-      region: 'AWS_REGION_NEAR_TO_YOU',
+      awsConfig: {
+        accessKeyId: 'YOUR_AWS_ACCESS_KEY_ID',
+        secretAccessKey: 'YOUR_AWS_ACCESS_KEY_ID',
+        region: 'AWS_REGION_NEAR_TO_YOU',
+        // ... any options you want to pass to the AWS instance
+      },
       bucket: 'YOUR_S3_BUCKET_NAME',
       basePath: 'ROOT_DIR_OF_ASSETS',
       fileSize: 1 * 1024 * 1024,
@@ -262,17 +265,28 @@ In this example, `uploadFile()` method will upload both thumbnail and original i
 interface MulterExtendedS3Options {
   /**
    * AWS Access Key ID
+   * @deprecated v2 use awsConfig instead
    */
-  readonly accessKeyId: string;
+  readonly accessKeyId?: string;
   /**
    * AWS Secret Access Key
+   * @deprecated v2 use awsConfig instead
    */
-  readonly secretAccessKey: string;
+  readonly secretAccessKey?: string;
   /**
    * Default region name
    * default: us-west-2
+   * @deprecated v2 use awsConfig instead
    */
-  readonly region: string;
+  readonly region?: string;
+  /**
+   * AWS Config
+   */
+  readonly awsConfig?: ConfigurationOptions & ConfigurationServicePlaceholders & APIVersions & {[key: string]: any};
+  /**
+   * S3 Config
+   */
+  readonly s3Config?: AWS.S3.Types.ClientConfiguration;
   /**
    * The name of Amazon S3 bucket
    */
@@ -287,8 +301,9 @@ interface MulterExtendedS3Options {
    * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
    */
   readonly acl?: string;
-  /*
+  /**
    * AWS Endpoint
+   * @deprecated v2 use s3Config instead
    */
   readonly endpoint?: string;
   /**

--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,5 +1,6 @@
 import { LoggerService } from '@nestjs/common';
-import { GlobalConfigInstance } from 'aws-sdk/lib/config';
+import { APIVersions, ConfigurationOptions } from 'aws-sdk/lib/config';
+import { ConfigurationServicePlaceholders } from 'aws-sdk/lib/config_service_placeholders';
 import AWS from 'aws-sdk';
 
 export interface MulterExtendedS3Options {
@@ -22,7 +23,9 @@ export interface MulterExtendedS3Options {
   /**
    * AWS Config
    */
-  readonly awsConfig?: GlobalConfigInstance;
+  readonly awsConfig?: ConfigurationOptions &
+    ConfigurationServicePlaceholders &
+    APIVersions & { [key: string]: any };
   /**
    * S3 Config
    */

--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,19 +1,32 @@
 import { LoggerService } from '@nestjs/common';
+import { GlobalConfigInstance } from 'aws-sdk/lib/config';
+import AWS from 'aws-sdk';
 
 export interface MulterExtendedS3Options {
   /**
    * AWS Access Key ID
+   * @deprecated v2 use awsConfig instead
    */
-  readonly accessKeyId: string;
+  readonly accessKeyId?: string;
   /**
    * AWS Secret Access Key
+   * @deprecated v2 use awsConfig instead
    */
-  readonly secretAccessKey: string;
+  readonly secretAccessKey?: string;
   /**
    * Default region name
    * default: us-west-2
+   * @deprecated v2 use awsConfig instead
    */
-  readonly region: string;
+  readonly region?: string;
+  /**
+   * AWS Config
+   */
+  readonly awsConfig?: GlobalConfigInstance;
+  /**
+   * S3 Config
+   */
+  readonly s3Config?: AWS.S3.Types.ClientConfiguration;
   /**
    * The name of Amazon S3 bucket
    */
@@ -30,6 +43,7 @@ export interface MulterExtendedS3Options {
   readonly acl?: string;
   /**
    * AWS Endpoint
+   * @deprecated v2 use s3Config instead
    */
   readonly endpoint?: string;
   /**

--- a/lib/multer-config.loader.ts
+++ b/lib/multer-config.loader.ts
@@ -1,7 +1,7 @@
 import AWS from 'aws-sdk';
 import { AmazonS3Storage, ImageFileExtensions, MulterExceptions } from './multer-sharp';
-import { Injectable, Inject, Logger, BadRequestException, LoggerService } from '@nestjs/common';
-import { MulterOptionsFactory, MulterModuleOptions } from '@nestjs/platform-express';
+import { BadRequestException, Inject, Injectable, Logger, LoggerService } from '@nestjs/common';
+import { MulterModuleOptions, MulterOptionsFactory } from '@nestjs/platform-express';
 import { MULTER_EXTENDED_S3_OPTIONS } from './constants';
 import { MulterExtendedS3Options } from './interfaces';
 
@@ -22,10 +22,12 @@ export class MulterConfigLoader implements MulterS3ConfigService {
       accessKeyId: s3Options.accessKeyId,
       secretAccessKey: s3Options.secretAccessKey,
       region: s3Options.region || MulterConfigLoader.DEFAULT_REGION,
+      ...s3Options.awsConfig,
     });
 
     this.S3 = new AWS.S3({
       endpoint: s3Options.endpoint,
+      ...s3Options.s3Config,
     });
     this.logger = s3Options.logger || new Logger(MulterConfigLoader.name);
     this.logger.log(JSON.stringify(s3Options));


### PR DESCRIPTION
Fixes #170 

Let me know if there's anything to adjust, I'd love to get this in, so we can pass all config options or none at all to the AWS/S3 Instances.