### PR TITLE
Update for newer version of aws-sdk where ConfigurationOptions has moved

### DIFF
--- a/lib/interfaces/multer-extended-s3-options.interface.ts
+++ b/lib/interfaces/multer-extended-s3-options.interface.ts
@@ -1,5 +1,6 @@
 import { LoggerService } from '@nestjs/common';
-import { APIVersions, ConfigurationOptions } from 'aws-sdk/lib/config';
+import { APIVersions } from 'aws-sdk/lib/config';
+import { ConfigurationOptions } from 'aws-sdk/lib/config-base';
 import { ConfigurationServicePlaceholders } from 'aws-sdk/lib/config_service_placeholders';
 import AWS from 'aws-sdk';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2777,11 +2777,11 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.610.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.610.0.tgz",
-      "integrity": "sha512-kqcoCTKjbxrUo2KeLQR2Jw6l4PvkbHXSDk8KqF2hXcpHibiOcMXZZPVe9X+s90RC/B2+qU95M7FImp9ByMcw7A==",
+      "version": "2.802.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.802.0.tgz",
+      "integrity": "sha512-PfjBr5Ag4PdcEYPrfMclVWk85kFSJNe7qllZBE8RhYNu+K+Z2pveKfYkC5mqYoKEYIQyI9by9N47F+Tqm1GXtg==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -3167,9 +3167,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@nestjs/platform-express": "^6.11.5 || ^7.0.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.610.0",
+    "aws-sdk": "^2.802.0",
     "mime-types": "^2.1.27",
     "sharp": "^0.26.0"
   },


### PR DESCRIPTION
In the current version of AWS SDK, the ConfigurationOptions type has moved from config to config-base